### PR TITLE
Fix test script on linux.

### DIFF
--- a/simple-test-cases-novra/run-test.sh
+++ b/simple-test-cases-novra/run-test.sh
@@ -16,7 +16,7 @@ else
 fi
 
 recompile_one() {
-  args=
+  args="-lm"
   input=$1
   ext=${1##*.}
   if [[ ( $ext = 'll' ) || ( $(basename $input) = test* ) ]]; then
@@ -55,7 +55,7 @@ recompile_one() {
       for testin in "$SCRIPTPATH"/input/${1%.*}.*; do
         [ -f "$testin" ] || continue
         printf '[TEST ] [....] %s' $(basename "$testin")
-        testout=$(mktemp -t $(basename "$testin"))
+        testout=$(mktemp -t $(basename "$testin").XXXXXX)
         "$out" < "$testin" > "$testout"
         correctout=${SCRIPTPATH}/output/$(basename "$testin")
         logf="$SCRIPTPATH"/$(basename "$testin").log

--- a/simple-test-cases/run-test.sh
+++ b/simple-test-cases/run-test.sh
@@ -16,7 +16,7 @@ else
 fi
 
 recompile_one() {
-  args=
+  args="-lm"
   input=$1
   ext=${1##*.}
   if [[ ( $ext = 'll' ) || ( $(basename $input) = test* ) ]]; then


### PR DESCRIPTION
mktemp for BSD (including OSX) requires a template,
but it allows any number of Xs in the template.
(GNU) mktemp for Linux does not require a template,
however, if a template is specified,
then the number of Xs must be 6.
https://unix.stackexchange.com/questions/30091/fix-or-alternative-for-mktemp-in-os-x

lm flag for linking added.